### PR TITLE
fix: use ref as string?

### DIFF
--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -19,7 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        ref: ${{ github.event.inputs.ref }}
+        with:
+          ref: ${{ github.event.inputs.ref }}
 
       - name: Create wrangler.toml
         run: ./scripts/make-wrangler.sh


### PR DESCRIPTION
Fixes:

```
The workflow is not valid. .github/workflows/dispatch_deploy.yml (Line: 22, Col: 9): Unexpected value 'ref'
```