### PR TITLE
Chore | Update reference to template and rename project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,24 +162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusty-cloudflare-worker"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "cfg-if 1.0.0",
- "console_error_panic_hook",
- "http",
- "serde",
- "serde_json",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test",
- "wee_alloc",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +367,24 @@ checksum = "8be2398f326b7ba09815d0b403095f34dd708579220d099caae89be0b32137b2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "website-cache-worker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cfg-if 1.0.0",
+ "console_error_panic_hook",
+ "http",
+ "serde",
+ "serde_json",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "wee_alloc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rusty-cloudflare-worker"
+name = "website-cache-worker"
 version = "0.1.0"
 authors = ["Esteban Borai <estebanborai@gmail.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <div align="center" style="display: block; text-align: center;">
     <img src="./assets/ferris_wasm.png" width="200" />
   </div>
-  <h1 align="center">rusty-cloudflare-worker</h1>
+  <h1 align="center">website-cache-worker</h1>
   <h4 align="center">👷🏻‍♂️ Rust Cloudflare Worker to handle HTTP requests</h4>
 </div>
 

--- a/scripts/make-wrangler.sh
+++ b/scripts/make-wrangler.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-WORKER_NAME="rusty-cloudflare-worker"
+WORKER_NAME="website-cache"
 CF_ACCOUNT_ID="<Provide your Account ID from Cloudflare Workers Website>"
 WORKERS_DEV=true
 


### PR DESCRIPTION
This is a proposal to change the name of this project to something less
ambiguous.

`website-worker` could be many things, _a worker which serves a website_,
_a proxy worker for a website_ or _a website data updater_.

The main purpose of this project is caching data for the website, so I propose
the rename project to `website-cache-worker`.

This PR also updates references used in the _rusty-cloudflare-worker_ template
to have our worker reachable on `website-cache.workers.dev` instead of
`rusty-cloudflare-worker.workers.dev`.

